### PR TITLE
minor changes to baseline and benchmark test cases #2 (#3)

### DIFF
--- a/compsets/all.input
+++ b/compsets/all.input
@@ -14,7 +14,9 @@ run cpld_fv3_384_mom6_cice_2d_atm_flux @ fv3, coupledapp, warm384
 #These can be run separately from the baseline test cases 
 #above by commenting those 4 tests out. The user must then 
 #first run the benchmark cold start alone. The location of
-#cold start mediator files is then used to run the warm start
+#cold start mediator files is then used to run the warm start.  
+#The full path to the cold start mediator files is specified as
+#MED_restart_data in benchmark_warm.input. 
 
 #load 'benchmark_cold.input'
 #load 'benchmark_warm.input'
@@ -27,7 +29,9 @@ run cpld_fv3_384_mom6_cice_2d_atm_flux @ fv3, coupledapp, warm384
 #These can be run separately from the baseline test cases
 #above by commenting those 4 tests out. The user must then
 #first run the 4 cold starts alone. The location of
-#cold start mediator files are then used to run the warm starts
+#cold start mediator files is then used to run the warm starts. The
+#full path to the cold start mediator files is specified as ROOTDIR
+#in the datesuite_warm.input.
 
 #load 'datesuite_cold.input'
 #run cpld_fv3_384_mom6_cice_cold_2012010100 @ benchmark, coldBM2

--- a/compsets/benchmark_cold.input
+++ b/compsets/benchmark_cold.input
@@ -14,7 +14,7 @@ test cpld_fv3_384_mom6_cice_cold_bmark: fv3_mom6_cice.exe {
     FNALBC="'global_snowfree_albedo.bosu.t766.1536.768.rg.grb',"
     FNVETC="'global_vegtype.igbp.t766.1536.768.rg.grb',"
     FNSOTC="'global_soiltype.statsgo.t766.1536.768.rg.grb',"
-    FNSMCC="'global_soilmgldas.t766.1536.768.grb',"
+    FNSMCC="'global_soilmgldas.statsgo.t766.1536.768.grb',"
     FNABSC="'global_mxsnoalb.uariz.t766.1536.768.rg.grb',"
 
     FV3_mosaic="C@[ATMRES]"

--- a/compsets/benchmark_warm.input
+++ b/compsets/benchmark_warm.input
@@ -20,7 +20,7 @@ test cpld_fv3_384_mom6_cice_2d_bmark: fv3_mom6_cice.exe {
     FNALBC="'global_snowfree_albedo.bosu.t766.1536.768.rg.grb',"
     FNVETC="'global_vegtype.igbp.t766.1536.768.rg.grb',"
     FNSOTC="'global_soiltype.statsgo.t766.1536.768.rg.grb',"
-    FNSMCC="'global_soilmgldas.t766.1536.768.grb',"
+    FNSMCC="'global_soilmgldas.statsgo.t766.1536.768.grb',"
     FNABSC="'global_mxsnoalb.uariz.t766.1536.768.rg.grb',"
 
     FV3_mosaic="C@[ATMRES]"
@@ -69,8 +69,9 @@ test cpld_fv3_384_mom6_cice_2d_bmark: fv3_mom6_cice.exe {
       CICE5_IC="@[BM_IC]/cpc"    
 
     # set location of cold start for mediator restarts
-    # THIS IS A USER's OWN RUN
-    MED_restart_data="/scratch2/NCEPDEV/stmp1/Denise.Worthen/BM_Test/@[CDATE]_cold/tmp/cpld_fv3_384_mom6_cice_cold_bmark"
+    # THIS IS A USER's OWN RUN and should reflect the full path to the location of the cold start
+    # eg: "/scratch2/NCEPDEV/stmp1/First.LastName/rtgen.NUMBER/tmp/cpld_fv3_384_mom6_cice_cold_bmark"
+    MED_restart_data="full-path-to-user-coldstart"
     RESTART_MED="mediator_*"    
 
     # - nems.configure --- 

--- a/compsets/cpld_fv3_mom6_cice_2d_atm_flux.input
+++ b/compsets/cpld_fv3_mom6_cice_2d_atm_flux.input
@@ -73,12 +73,6 @@ test cpld_fv3_mom6_cice_2d_atm_flux: fv3_mom6_cice.exe {
     # Specify input files. 
     filters input { 
       #    WORK FILE  <=filter=   SOURCE FILE 
-                     'input.nml'  <=atparse=  "@[PARMnems]/@[INPUT_NML]"
-               'model_configure'  <=atparse=  "@[PARMnems]/model_configure.IN"
-               'ice_in_template'  <=copy=     "@[PARMnems]/ice_in_template"
-      'INPUT/MOM_input_template'  <=copy=     "@[PARMnems]/MOM_input_template"
-           'diag_table_template'  <=copy=     "@[PARMnems]/diag_table_template"
-                "nems.configure"  <=atparse=  "@[PARMnems]/nems.configure.@[nems_configure].IN"
 #FV3 fixed input
                    'aerosol.dat'  <=copyfrom= "@[FV3_input_data]/INPUT"
     'co2historicaldata_201*.txt'  <=copyfrom= "@[CO2_data]"
@@ -105,6 +99,13 @@ test cpld_fv3_mom6_cice_2d_atm_flux: fv3_mom6_cice.exe {
                  'INPUT/MOM*.nc'  <=copyfrom= "@[MOM6_IC]"
             'cice5_model.res.nc'  <=copy=     "@[CICE5_IC]/cice5_model_0.25.res_@[CDATE].nc"
                 "@[RESTART_MED]"  <=copyfrom= "@[MED_restart_data]"
+# namelists,templates and configurations
+                     'input.nml'  <=atparse=  "@[PARMnems]/@[INPUT_NML]"
+               'model_configure'  <=atparse=  "@[PARMnems]/model_configure.IN"
+               'ice_in_template'  <=copy=     "@[PARMnems]/ice_in_template"
+      'INPUT/MOM_input_template'  <=copy=     "@[PARMnems]/MOM_input_template"
+           'diag_table_template'  <=copy=     "@[PARMnems]/diag_table_template"
+                "nems.configure"  <=atparse=  "@[PARMnems]/nems.configure.@[nems_configure].IN"
     } 
  
     # Edit the templates for the compset parameters

--- a/compsets/cpld_fv3_mom6_cice_cold_atm_flux.input
+++ b/compsets/cpld_fv3_mom6_cice_cold_atm_flux.input
@@ -71,12 +71,6 @@ test cpld_fv3_mom6_cice_cold_atm_flux: fv3_mom6_cice.exe {
     # Specify input files. 
     filters input { 
       #    WORK FILE  <=filter=   SOURCE FILE 
-                     'input.nml'  <=atparse=  "@[PARMnems]/@[INPUT_NML]"
-               'model_configure'  <=atparse=  "@[PARMnems]/model_configure.IN"
-               'ice_in_template'  <=copy=     "@[PARMnems]/ice_in_template"
-      'INPUT/MOM_input_template'  <=copy=     "@[PARMnems]/MOM_input_template"
-           'diag_table_template'  <=copy=     "@[PARMnems]/diag_table_template"
-                "nems.configure"  <=atparse=  "@[PARMnems]/nems.configure.@[nems_configure].IN"
 #FV3 fixed input
                    'aerosol.dat'  <=copyfrom= "@[FV3_input_data]/INPUT"
     'co2historicaldata_201*.txt'  <=copyfrom= "@[CO2_data]"
@@ -102,6 +96,13 @@ test cpld_fv3_mom6_cice_cold_atm_flux: fv3_mom6_cice.exe {
             'INPUT/gfs_data*.nc'  <=copyfrom= "@[FV3_IC]"
                  'INPUT/MOM*.nc'  <=copyfrom= "@[MOM6_IC]"
             'cice5_model.res.nc'  <=copy=     "@[CICE5_IC]/cice5_model_0.25.res_@[CDATE].nc"
+# namelists,templates and configurations
+                     'input.nml'  <=atparse=  "@[PARMnems]/@[INPUT_NML]"
+               'model_configure'  <=atparse=  "@[PARMnems]/model_configure.IN"
+               'ice_in_template'  <=copy=     "@[PARMnems]/ice_in_template"
+      'INPUT/MOM_input_template'  <=copy=     "@[PARMnems]/MOM_input_template"
+           'diag_table_template'  <=copy=     "@[PARMnems]/diag_table_template"
+                "nems.configure"  <=atparse=  "@[PARMnems]/nems.configure.@[nems_configure].IN"
     } 
  
     # Edit the templates for the compset parameters

--- a/compsets/datesuite_warm.input
+++ b/compsets/datesuite_warm.input
@@ -2,7 +2,9 @@
 load 'benchmark_warm.input'
 
    # set this as the location of the 4 cold starts
-   ROOTDIR = "/scratch2/NCEPDEV/stmp1/Denise.Worthen/coldstarts"
+   # THIS IS A USERS OWN RUN and should reflect the path to the location of the cold starts
+   # eg: "/scratch2/NCEPDEV/stmp1/First.LastName/rtgen.NUMBER"
+   ROOTDIR = "path-to-user-coldstarts"
 
     DAYS='5'
    FHMAX='120'

--- a/log/report-hera.intel-log/build_fv3_mom6_cice.exe.log
+++ b/log/report-hera.intel-log/build_fv3_mom6_cice.exe.log
@@ -1,21 +1,21 @@
 + [[ fv3_mom6_cice.exe == fv3_mom6_cice.exe ]]
-+ rm -f /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/exec/fv3_mom6_cice.exe
-+ md5sum=/scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/exec/fv3_mom6_cice.exe.md5
++ rm -f /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/exec/fv3_mom6_cice.exe
++ md5sum=/scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/exec/fv3_mom6_cice.exe.md5
 + OPTS=app=coupledFV3_MOM6_CICE
-+ mkdir -p /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/exec /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/include
-+ rm -f /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/exec/fv3_mom6_cice.exe /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/include/modules_fv3_mom6_cice
-+ cd /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster
++ mkdir -p /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/exec /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/include
++ rm -f /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/exec/fv3_mom6_cice.exe /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/include/modules_fv3_mom6_cice
++ cd /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model
 + which aprun
 which: no aprun in (/scratch1/NCEPDEV/nems/emc.nemspara/soft/emc-utils/1.1.0/bin:/apps/hpss:/apps/rocoto/1.3.1/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/opt/ibutils/bin:/apps/local/bin:/apps/local/sbin:/apps/slurm/default/slurm/tools:/apps/slurm/default/bin:/apps/slurm/default/sbin:/apps/slurm/tools/sbank/bin)
 + ./NEMS/NEMSAppBuilder norebuild app=coupledFV3_MOM6_CICE
 ls: cannot access ../conf/component_*.mk: No such file or directory
 NEMSAppBuilder: make  app=coupledFV3_MOM6_CICE build
-Convert /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/coupledFV3_MOM6_CICE.appBuilder
-...into /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/coupledFV3_MOM6_CICE.appBuilder.mk
-Include /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/coupledFV3_MOM6_CICE.appBuilder.mk
-echo 'FMS FV3 MOM6 CICE' > "/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/components.mk"
+Convert /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/coupledFV3_MOM6_CICE.appBuilder
+...into /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/coupledFV3_MOM6_CICE.appBuilder.mk
+Include /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/coupledFV3_MOM6_CICE.appBuilder.mk
+echo 'FMS FV3 MOM6 CICE' > "/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/components.mk"
 Adding FV3 makeopts to FMS makeopts
-. /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; cd /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/fv3gfs                      ; \
+. /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; cd /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/fv3gfs                      ; \
 exec make  all
 
 Currently Loaded Modules:
@@ -27,19 +27,19 @@ Currently Loaded Modules:
 
  
 
-make[1]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/fv3gfs'
-mkdir -p "/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL"
-mv fms.mk "/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL/."
-cp -fp *.a *.mod ../include/*.h "/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL"/.
-make[1]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/fv3gfs'
-test -d /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL
-Compiling  into /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL on hera
-cp -fp /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/configure.nems \
-       "/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3"/conf/configure.fv3
-cp -fp /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/modules.nems   \
-       "/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3"/conf/modules.fv3
-. /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; cd /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3 ; \
-  exec make COMP=FV3 COMP_SRCDIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3 COMP_BINDIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL MACHINE_ID=hera FMS_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL  nemsinstall
+make[1]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/fv3gfs'
+mkdir -p "/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL"
+mv fms.mk "/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL/."
+cp -fp *.a *.mod ../include/*.h "/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL"/.
+make[1]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/fv3gfs'
+test -d /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL
+Compiling  into /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL on hera
+cp -fp /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/configure.nems \
+       "/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3"/conf/configure.fv3
+cp -fp /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/modules.nems   \
+       "/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3"/conf/modules.fv3
+. /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; cd /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3 ; \
+  exec make COMP=FV3 COMP_SRCDIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3 COMP_BINDIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL MACHINE_ID=hera FMS_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL  nemsinstall
 
 Currently Loaded Modules:
   1) contrib            6) bacio/2.0.3   11) w3nco/2.0.7     16) png/1.2.44
@@ -50,71 +50,71 @@ Currently Loaded Modules:
 
  
 
-make[1]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3'
-make -C cpl                  FMS_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL
+make[1]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3'
+make -C cpl                  FMS_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL
 
 Build standalone FV3 io ...
 
-make[2]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/cpl'
+make[2]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/cpl'
 make[2]: Nothing to be done for `all'.
-make[2]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/cpl'
-make -C gfsphysics      FMS_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL 32BIT=N  # force gfs physics to 64bit
+make[2]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/cpl'
+make -C gfsphysics      FMS_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL 32BIT=N  # force gfs physics to 64bit
 
 Build standalone FV3 gfsphysics ...
 
-make[2]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/gfsphysics'
+make[2]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/gfsphysics'
 make[2]: Nothing to be done for `all'.
-make[2]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/gfsphysics'
-make -C ipd                  FMS_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL 32BIT=N  # force gfs physics to 64bit
+make[2]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/gfsphysics'
+make -C ipd                  FMS_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL 32BIT=N  # force gfs physics to 64bit
 
 Build standalone FV3 gfsphysics ...
 
-make[2]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/ipd'
+make[2]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/ipd'
 make[2]: Nothing to be done for `all'.
-make[2]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/ipd'
-make -C io                   FMS_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL
+make[2]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/ipd'
+make -C io                   FMS_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL
 
 Build standalone FV3 io ...
 
 $ESMF_INC is [-I/scratch1/NCEPDEV/nems/emc.nemspara/soft/esmf/8.0.0-intel18.0.5.274-impi2018.0.4-netcdf4.6.1/mod -I/scratch1/NCEPDEV/nems/emc.nemspara/soft/esmf/8.0.0-intel18.0.5.274-impi2018.0.4-netcdf4.6.1/include -I/apps/netcdf/4.6.1/intel/16.1.150/include]
-make[2]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/io'
+make[2]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/io'
 make[2]: Nothing to be done for `all'.
-make[2]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/io'
-make -C atmos_cubed_sphere   FMS_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL
+make[2]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/io'
+make -C atmos_cubed_sphere   FMS_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL
 
 Build standalone FV3 fv3core ...
 
-make[2]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/atmos_cubed_sphere'
+make[2]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/atmos_cubed_sphere'
 make[2]: Nothing to be done for `all'.
-make[2]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/atmos_cubed_sphere'
-make -C ../stochastic_physics   FMS_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL 32BIT=N  # force gfs physics to 64bit
+make[2]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/atmos_cubed_sphere'
+make -C ../stochastic_physics   FMS_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL 32BIT=N  # force gfs physics to 64bit
 
 Build standalone FV3 stochastic_physics ...
 
-make[2]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/stochastic_physics'
+make[2]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/stochastic_physics'
 make[2]: Nothing to be done for `all'.
-make[2]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/stochastic_physics'
-make libfv3cap.a  FMS_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL
-make[2]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3'
+make[2]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/stochastic_physics'
+make libfv3cap.a  FMS_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL
+make[2]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3'
 make[2]: `libfv3cap.a' is up to date.
-make[2]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3'
-make esmf_make_fragment FMS_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL
-make[2]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3'
+make[2]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3'
+make esmf_make_fragment FMS_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL
+make[2]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3'
 # additional include files needed for PGI
-#@echo "ESMF_DEP_INCPATH   = /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/nems_dir" >> fv3.mk
+#@echo "ESMF_DEP_INCPATH   = /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/nems_dir" >> fv3.mk
 
 Finished generating ESMF self-describing build dependency makefile fragment: fv3.mk
 
-make[2]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3'
-Installation into "/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL" complete!
+make[2]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3'
+Installation into "/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL" complete!
 
-make[1]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3'
-test -d /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL
-rm -fr /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6/exec
-. /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; export COMP_SRCDIR="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6" COMP_BINDIR="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL" FMS_BINDIR="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL" MACHINE_ID="hera"                     ; \
+make[1]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3'
+test -d /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL
+rm -fr /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6/exec
+. /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; export COMP_SRCDIR="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6" COMP_BINDIR="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL" FMS_BINDIR="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL" MACHINE_ID="hera"                     ; \
 set -e                                                        ; \
-cd /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6                                             ; \
-./compile.sh --platform hera --fms-dir "/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL"
+cd /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6                                             ; \
+./compile.sh --platform hera --fms-dir "/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL"
 
 Currently Loaded Modules:
   1) contrib            6) bacio/2.0.3   11) w3nco/2.0.7     16) png/1.2.44
@@ -125,9 +125,9 @@ Currently Loaded Modules:
 
  
 
-Will use FMS from: /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL
+Will use FMS from: /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL
 ++ pwd
-+ BASEDIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6
++ BASEDIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6
 + MACHINE_ID=hera
 + COMPILE_OPTION=hera-intel.mk
 + compile_MOM6_LIB=1
@@ -136,7 +136,7 @@ Will use FMS from: /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_
 + [[ 1 == 1 ]]
 + echo 'compile MOM6 library ...'
 compile MOM6 library ...
-+ cd /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6
++ cd /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6
 + mkdir -p build/intel/MOM6_LIB/repro
 + cd build/intel/MOM6_LIB/repro
 + [[ -f path_names ]]
@@ -147,32 +147,32 @@ generating file_paths ...
 A list of the files you checked out is in the file path_names.
 + echo 'generating makefile ...'
 generating makefile ...
-+ ../../../../src/mkmf/bin/mkmf -t ../../../../src/mkmf/templates/hera-intel.mk -p lib_ocean.a -o -I/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL path_names
++ ../../../../src/mkmf/bin/mkmf -t ../../../../src/mkmf/templates/hera-intel.mk -p lib_ocean.a -o -I/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL path_names
 ........................................................................................................................................................................................................................................... Makefile is ready.
 + echo 'compiling MOM6 library...'
 compiling MOM6 library...
 + make NETCDF=4 REPRO=1 lib_ocean.a
-make[1]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6/build/intel/MOM6_LIB/repro'
+make[1]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6/build/intel/MOM6_LIB/repro'
 make[1]: `lib_ocean.a' is up to date.
-make[1]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6/build/intel/MOM6_LIB/repro'
+make[1]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6/build/intel/MOM6_LIB/repro'
 + echo 'compiling MOM6 library successful'
 compiling MOM6 library successful
 + echo 'compiling MOM6 library done'
 compiling MOM6 library done
-+ cd /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6
++ cd /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6
 + mkdir -p exec/hera/
-+ ln -s /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6/build/intel/MOM6_LIB/repro exec/hera/lib_ocean
++ ln -s /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6/build/intel/MOM6_LIB/repro exec/hera/lib_ocean
 + [[ 0 == 1 ]]
 + echo ==================================================
 ==================================================
 + [[ 0 == 1 ]]
 + echo 'Next recommended step is to rejoice out of happiness from a successful compile.'
 Next recommended step is to rejoice out of happiness from a successful compile.
-. /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; cd /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6                          ; \
-  exec make -f makefile.nuopc COMP_SRCDIR="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6" COMP_BINDIR="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL" FMS_BINDIR="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL" MACHINE_ID="hera"               \
-  "FMSDIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL"                                        \
-  "NEMSMOMDIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6/exec/hera"                \
-  "INSTALLDIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL" install
+. /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; cd /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6                          ; \
+  exec make -f makefile.nuopc COMP_SRCDIR="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6" COMP_BINDIR="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL" FMS_BINDIR="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL" MACHINE_ID="hera"               \
+  "FMSDIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL"                                        \
+  "NEMSMOMDIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6/exec/hera"                \
+  "INSTALLDIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL" install
 
 Currently Loaded Modules:
   1) contrib            6) bacio/2.0.3   11) w3nco/2.0.7     16) png/1.2.44
@@ -183,19 +183,19 @@ Currently Loaded Modules:
 
  
 
-make[1]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6'
+make[1]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6'
 rm -f mom6.mk.install
-mkdir -p /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL
-cp -f /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6/exec/hera/lib_ocean/lib_ocean.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL
-cp -f libmom.a mom_cap_mod.mod /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL
-cp -f mom6.mk.install /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL/mom6.mk
-make[1]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6'
-test -d "/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL"
-test -s "/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL/mom6.mk"
-. /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack                                                   ; \
+mkdir -p /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL
+cp -f /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6/exec/hera/lib_ocean/lib_ocean.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL
+cp -f libmom.a mom_cap_mod.mod /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL
+cp -f mom6.mk.install /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL/mom6.mk
+make[1]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6'
+test -d "/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL"
+test -s "/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL/mom6.mk"
+. /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack                                                   ; \
 set -eu                                                           ; \
-export COMP_SRCDIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE COMP_BINDIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL SITE="NEMS.hera" SYSTEM_USERDIR="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE" SRCDIR="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE" EXEDIR="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE" NEMS_GRID="T126_mx5"                                           ; \
-cd /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE                                                 ; \
+export COMP_SRCDIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE COMP_BINDIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL SITE="NEMS.hera" SYSTEM_USERDIR="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE" SRCDIR="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE" EXEDIR="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE" NEMS_GRID="T126_mx5"                                           ; \
+cd /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE                                                 ; \
 ./comp_ice.backend
 
 Currently Loaded Modules:
@@ -210,10 +210,10 @@ Currently Loaded Modules:
 NEMS_GRID = T126_mx025 
 tcx comp_ice.backend res grid mx025 1440x1080
 ARCH is Linux.NEMS.hera
-gmake[1]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_SRC/lanl_cice/compile'
+gmake[1]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_SRC/lanl_cice/compile'
 gmake[1]: Nothing to be done for `all'.
-gmake[1]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_SRC/lanl_cice/compile'
-/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_SRC/lanl_cice
+gmake[1]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_SRC/lanl_cice/compile'
+/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_SRC/lanl_cice
 NTASK = 48
 global N, block_size
 x    1440,    60
@@ -227,9 +227,9 @@ max_blocks = 1
 0 = TRBRI, brine height tracer
 7 = NBGCLYR, number of bio grid layers
 0 = TRBGCS, number of BGC tracers
-. /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; cd /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_CAP ; exec make -f makefile.nuopc    \
-  COMP_SRCDIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE COMP_BINDIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL SITE="NEMS.hera" SYSTEM_USERDIR="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE" SRCDIR="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE" EXEDIR="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE" NEMS_GRID="T126_mx5"                                                  \
-  "LANLCICEDIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE" "INSTALLDIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL" install
+. /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack ; cd /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_CAP ; exec make -f makefile.nuopc    \
+  COMP_SRCDIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE COMP_BINDIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL SITE="NEMS.hera" SYSTEM_USERDIR="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE" SRCDIR="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE" EXEDIR="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE" NEMS_GRID="T126_mx5"                                                  \
+  "LANLCICEDIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE" "INSTALLDIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL" install
 
 Currently Loaded Modules:
   1) contrib            6) bacio/2.0.3   11) w3nco/2.0.7     16) png/1.2.44
@@ -240,30 +240,30 @@ Currently Loaded Modules:
 
  
 
-make[1]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_SRC/lanl_cice_cap'
+make[1]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_SRC/lanl_cice_cap'
 rm -f cice.mk.install
-mkdir -p /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL
-cp -f /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE/liblanl_cice.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL
-cp -f libcice.a cice_cap_mod.mod /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL 
-cp -f cice.mk.install /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL/cice.mk
-make[1]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_SRC/lanl_cice_cap'
-test -f /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL/cice.mk
+mkdir -p /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL
+cp -f /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE/liblanl_cice.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL
+cp -f libcice.a cice_cap_mod.mod /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL 
+cp -f cice.mk.install /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL/cice.mk
+make[1]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_SRC/lanl_cice_cap'
+test -f /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL/cice.mk
 ( \
 echo "# Do not edit this file.  It is automatically generated." ; \
-echo "# Edit the component list or /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/configure.nems.NUOPC.in"                          ; \
-echo ; cat "/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/configure.nems.NUOPC.in"                                                 ; \
-echo fms_mk="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL/fms.mk" ; echo fv3_mk="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL/fv3.mk" ; echo mom6_mk="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL/mom6.mk" ; echo cice_mk="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL/cice.mk" ; ) > "/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/configure.nems.NUOPC"
-. /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack                                         ; \
+echo "# Edit the component list or /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/configure.nems.NUOPC.in"                          ; \
+echo ; cat "/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/configure.nems.NUOPC.in"                                                 ; \
+echo fms_mk="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL/fms.mk" ; echo fv3_mk="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL/fv3.mk" ; echo mom6_mk="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL/mom6.mk" ; echo cice_mk="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL/cice.mk" ; ) > "/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/configure.nems.NUOPC"
+. /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf/module-setup.sh.inc ; stack=`ulimit -S -s`                  ; ulimit -S -s 200000                     ; module use /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/conf                 ; module load modules.nems              ; module list                           ; ulimit -S -s $stack                                         ; \
 set -e                                                  ; \
-for m in /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL/fms.mk /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL/fv3.mk /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL/mom6.mk /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL/cice.mk ; do                   \
+for m in /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL/fms.mk /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL/fv3.mk /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL/mom6.mk /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL/cice.mk ; do                   \
   test -s $m                                           ; \
 done                                                    ; \
-echo build NEMS after /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL/fms.mk /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL/fv3.mk /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL/mom6.mk /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL/cice.mk         ; \
-cd /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src                                       ; \
+echo build NEMS after /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL/fms.mk /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL/fv3.mk /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL/mom6.mk /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL/cice.mk         ; \
+cd /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src                                       ; \
 make nems                              \
           COMPONENTS="FMS FV3 MOM6 CICE"                      \
-          FMS_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL FV3_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL MOM6_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL CICE_DIR=/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL TARGET="/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/exe/NEMS.x"    ; \
-test -x /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/exe/NEMS.x
+          FMS_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL FV3_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL MOM6_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL CICE_DIR=/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL TARGET="/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/exe/NEMS.x"    ; \
+test -x /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/exe/NEMS.x
 
 Currently Loaded Modules:
   1) contrib            6) bacio/2.0.3   11) w3nco/2.0.7     16) png/1.2.44
@@ -274,12 +274,12 @@ Currently Loaded Modules:
 
  
 
-build NEMS after /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL/fms.mk /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL/fv3.mk /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL/mom6.mk /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL/cice.mk
+build NEMS after /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL/fms.mk /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL/fv3.mk /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL/mom6.mk /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL/cice.mk
 Components in linker order: CICE MOM6 FV3 FMS
-CICE: include /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL/cice.mk
-MOM6: include /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL/mom6.mk
-FV3: include /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL/fv3.mk
-FMS: include /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL/fms.mk
+CICE: include /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL/cice.mk
+MOM6: include /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL/mom6.mk
+FV3: include /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL/fv3.mk
+FMS: include /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL/fms.mk
 CPPFLAGS += ESMF_VERSION_STRING_GIT="ESMF_8_0_0"
 CPPFLAGS += ESMF_VERSION_BETASNAPSHOT="'F'"
 CPPFLAGS += ESMF_VERSION_MINOR="0"
@@ -288,33 +288,33 @@ CPPFLAGS += ESMF_VERSION_STRING="8.0.0"
 CPPFLAGS += ESMF_VERSION_REVISION="0"
 CPPFLAGS += ESMF_VERSION_MAJOR="8"
 CPPFLAGS += ESMF_VERSION_PUBLIC="'T'"
-make[1]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src'
+make[1]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src'
 cd ENS_Cpl             && make stub
-make[2]: Entering directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/ENS_Cpl'
+make[2]: Entering directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/ENS_Cpl'
 ar rv ENS_Cpl.a ENS_CplComp_ESMFMod_STUB.o
 r - ENS_CplComp_ESMFMod_STUB.o
-make[2]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src/ENS_Cpl'
+make[2]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src/ENS_Cpl'
 echo libgocart is 
 libgocart is
 echo extlibs is /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libncep_post_v8.0.0_4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libnemsio_v2.2.4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libg2_v3.1.1_4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libg2tmpl_v1.5.1.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libbacio_v2.0.3_4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libsp_v2.0.3_d.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libw3emc_v2.3.1_d.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libw3nco_v2.0.7_d.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libcrtm_v2.2.6.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libpng_v1.2.44.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/gnu/4.8.5/lib/libjasper_v1.900.1.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libz_v1.2.11.a -L/scratch1/NCEPDEV/nems/emc.nemspara/soft/esmf/8.0.0-intel18.0.5.274-impi2018.0.4-netcdf4.6.1/lib -Wl,-rpath,/scratch1/NCEPDEV/nems/emc.nemspara/soft/esmf/8.0.0-intel18.0.5.274-impi2018.0.4-netcdf4.6.1/lib -lesmf  -cxxlib -lrt -ldl -lnetcdff -lnetcdf  -qopenmp  -L/apps/netcdf/4.7.0/intel/18.0.5.274/lib -lnetcdff -lnetcdf
 extlibs is /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libncep_post_v8.0.0_4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libnemsio_v2.2.4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libg2_v3.1.1_4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libg2tmpl_v1.5.1.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libbacio_v2.0.3_4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libsp_v2.0.3_d.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libw3emc_v2.3.1_d.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libw3nco_v2.0.7_d.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libcrtm_v2.2.6.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libpng_v1.2.44.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/gnu/4.8.5/lib/libjasper_v1.900.1.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libz_v1.2.11.a -L/scratch1/NCEPDEV/nems/emc.nemspara/soft/esmf/8.0.0-intel18.0.5.274-impi2018.0.4-netcdf4.6.1/lib -Wl,-rpath,/scratch1/NCEPDEV/nems/emc.nemspara/soft/esmf/8.0.0-intel18.0.5.274-impi2018.0.4-netcdf4.6.1/lib -lesmf -cxxlib -lrt -ldl -lnetcdff -lnetcdf -qopenmp -L/apps/netcdf/4.7.0/intel/18.0.5.274/lib -lnetcdff -lnetcdf
-mpiifort  -o /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/exe/NEMS.x MAIN_NEMS.o module_NEMS_UTILS.o module_MEDIATOR_methods.o module_MEDIATOR.o module_MEDIATOR_SpaceWeather.o module_EARTH_INTERNAL_STATE.o module_EARTH_GRID_COMP.o module_NEMS_INTERNAL_STATE.o module_NEMS_GRID_COMP.o module_NEMS_Rusage.o nems_c_rusage.o  /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL/libcice.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/CICE_INSTALL/liblanl_cice.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL/libmom.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/MOM6_INSTALL/lib_ocean.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL/libfv3cap.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL/libfv3core.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL/libfv3io.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL/libipd.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL/libgfsphys.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL/libfv3cpl.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FV3/FV3_INSTALL/libstochastic_physics.a /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/FMS/FMS_INSTALL/libfms.a ENS_Cpl/ENS_Cpl.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libncep_post_v8.0.0_4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libnemsio_v2.2.4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libg2_v3.1.1_4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libg2tmpl_v1.5.1.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libbacio_v2.0.3_4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libsp_v2.0.3_d.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libw3emc_v2.3.1_d.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libw3nco_v2.0.7_d.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libcrtm_v2.2.6.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libpng_v1.2.44.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/gnu/4.8.5/lib/libjasper_v1.900.1.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libz_v1.2.11.a -L/scratch1/NCEPDEV/nems/emc.nemspara/soft/esmf/8.0.0-intel18.0.5.274-impi2018.0.4-netcdf4.6.1/lib -Wl,-rpath,/scratch1/NCEPDEV/nems/emc.nemspara/soft/esmf/8.0.0-intel18.0.5.274-impi2018.0.4-netcdf4.6.1/lib -lesmf  -cxxlib -lrt -ldl -lnetcdff -lnetcdf  -qopenmp  -L/apps/netcdf/4.7.0/intel/18.0.5.274/lib -lnetcdff -lnetcdf  
+mpiifort  -o /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/exe/NEMS.x MAIN_NEMS.o module_NEMS_UTILS.o module_MEDIATOR_methods.o module_MEDIATOR.o module_MEDIATOR_SpaceWeather.o module_EARTH_INTERNAL_STATE.o module_EARTH_GRID_COMP.o module_NEMS_INTERNAL_STATE.o module_NEMS_GRID_COMP.o module_NEMS_Rusage.o nems_c_rusage.o  /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL/libcice.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/CICE_INSTALL/liblanl_cice.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL/libmom.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/MOM6_INSTALL/lib_ocean.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL/libfv3cap.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL/libfv3core.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL/libfv3io.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL/libipd.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL/libgfsphys.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL/libfv3cpl.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FV3/FV3_INSTALL/libstochastic_physics.a /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/FMS/FMS_INSTALL/libfms.a ENS_Cpl/ENS_Cpl.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libncep_post_v8.0.0_4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libnemsio_v2.2.4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libg2_v3.1.1_4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libg2tmpl_v1.5.1.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libbacio_v2.0.3_4.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libsp_v2.0.3_d.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libw3emc_v2.3.1_d.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libw3nco_v2.0.7_d.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libcrtm_v2.2.6.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libpng_v1.2.44.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/gnu/4.8.5/lib/libjasper_v1.900.1.a /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/intel/18.0.5.274/lib/libz_v1.2.11.a -L/scratch1/NCEPDEV/nems/emc.nemspara/soft/esmf/8.0.0-intel18.0.5.274-impi2018.0.4-netcdf4.6.1/lib -Wl,-rpath,/scratch1/NCEPDEV/nems/emc.nemspara/soft/esmf/8.0.0-intel18.0.5.274-impi2018.0.4-netcdf4.6.1/lib -lesmf  -cxxlib -lrt -ldl -lnetcdff -lnetcdf  -qopenmp  -L/apps/netcdf/4.7.0/intel/18.0.5.274/lib -lnetcdff -lnetcdf  
 /scratch2/NCEPDEV/nwprod/NCEPLIBS/compilers/gnu/4.8.5/lib/libjasper_v1.900.1.a(jas_stream.o): In function `jas_stream_tmpfile':
 jas_stream.c:(.text+0x7a7): warning: the use of `tmpnam' is dangerous, better use `mkstemp'
-/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/exe/NEMS.x is created.
-make[1]: Leaving directory `/scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src'
-+ cd /scratch2/NCEPDEV/ocean/Denise.Worthen/FMC_newmaster/NEMS/src
-+ cp -fp ../exe/NEMS.x /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/exec/fv3_mom6_cice.exe
-+ cp -fp conf/modules.nems /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/include/modules_fv3_mom6_cice
-+ md5sum /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/exec/fv3_mom6_cice.exe
+/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/exe/NEMS.x is created.
+make[1]: Leaving directory `/scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src'
++ cd /scratch2/NCEPDEV/climate/Denise.Worthen/WORK/S2S_model/NEMS/src
++ cp -fp ../exe/NEMS.x /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/exec/fv3_mom6_cice.exe
++ cp -fp conf/modules.nems /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/include/modules_fv3_mom6_cice
++ md5sum /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/exec/fv3_mom6_cice.exe
 + unset md5sum
 + unset OPTS
 + set -xe
 + set -xe
-+ test -s /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/exec/fv3_mom6_cice.exe
-+ test -x /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/exec/fv3_mom6_cice.exe
++ test -s /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/exec/fv3_mom6_cice.exe
++ test -x /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/exec/fv3_mom6_cice.exe
 _______________________________________________________________
-Start Epilog v19.07.23 on node h1c16 for job 661943 :: Fri Nov 8 17:26:22 UTC 2019
-Job 661943 (not serial) finished for user Denise.Worthen in partition hera with exit code 0:0
+Start Epilog v19.07.23 on node h14c34 for job 753347 :: Wed Nov 13 15:40:43 UTC 2019
+Job 753347 (not serial) finished for user Denise.Worthen in partition hera with exit code 0:0
 _______________________________________________________________
-End Epilogue v19.07.23 Fri Nov 8 17:26:22 UTC 2019
+End Epilogue v19.07.23 Wed Nov 13 15:40:43 UTC 2019

--- a/log/report-hera.intel-log/rtreport.txt
+++ b/log/report-hera.intel-log/rtreport.txt
@@ -1,15 +1,18 @@
 Run rocotostat...
 Generate report...
-WORKFLOW STARTED AT Fri Nov  8 17:25:19 2019 (+1573233919)
+WORKFLOW STARTED AT Wed Nov 13 15:39:46 2019 (+1573659586)
 Repository information:
 
 
 REPO TOP:
-master   7763bd7 [origin/master] Updating MOM6 submodules to point to NOAA-EMC Other updates for running compsets on wcoss-phase2 and updates to match fv3atm commit on ufs-weather-app
-Fetch URL: gerrit:EMC_FV3-MOM6-CICE5
- D compsets/benchmark2_cold.input
- D compsets/benchmark2_warm.input
- M compsets/fv3mom6cice5.input
+feature/update_compsets 9f503e9 Updated README.md
+Fetch URL: https://github.com/DeniseWorthen/ufs-s2s-model.git
+ M compsets/all.input
+ M compsets/benchmark_cold.input
+ M compsets/benchmark_warm.input
+ M compsets/cpld_fv3_mom6_cice_2d_atm_flux.input
+ M compsets/cpld_fv3_mom6_cice_cold_atm_flux.input
+ M compsets/datesuite_warm.input
  M log/report-hera.intel-log/build_fv3_mom6_cice.exe.log
  M log/report-hera.intel-log/rtreport.txt
 
@@ -41,8 +44,8 @@ Fetch URL: https://github.com/noaa-psd/stochastic_physics
 BUILD fv3_mom6_cice.exe: SUCCEEDED
 
 TEST #1: PASS
-  Test cpld_fv3_384_mom6_cice_2d_atm_flux starting at Fri Nov 8 17:27:21 UTC 2019 (Fully coupled FV3-MOM6-CICE system - 2d_warm)
-  Fri Nov  8 17:27:21 UTC 2019
+  Test cpld_fv3_384_mom6_cice_2d_atm_flux starting at Wed Nov 13 16:03:55 UTC 2019 (Fully coupled FV3-MOM6-CICE system - 2d_warm)
+  Wed Nov 13 16:03:55 UTC 2019
   phyf048.tile1.nc: bit-for-bit identical
   phyf048.tile2.nc: bit-for-bit identical
   phyf048.tile3.nc: bit-for-bit identical
@@ -56,14 +59,14 @@ TEST #1: PASS
   dynf048.tile5.nc: bit-for-bit identical
   dynf048.tile6.nc: bit-for-bit identical
   Executable did not change during test suite:
-    File: /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/exec/fv3_mom6_cice.exe
-    Expected md5sum: 5d3e0efa487527efac2d7e32d3d0a113
-    Actual md5sum: 5d3e0efa487527efac2d7e32d3d0a113
-  TEST PASSED AT Fri Nov  8 18:17:53 UTC 2019
+    File: /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/exec/fv3_mom6_cice.exe
+    Expected md5sum: fa0dba069b6668cf64f6e10529c0e5e1
+    Actual md5sum: fa0dba069b6668cf64f6e10529c0e5e1
+  TEST PASSED AT Wed Nov 13 16:53:43 UTC 2019
 
 TEST #2: PASS
-  Test cpld_fv3_384_mom6_cice_cold_atm_flux starting at Fri Nov 8 17:27:18 UTC 2019 (Fully coupled FV3-MOM6-CICE system - cold 384)
-  Fri Nov  8 17:27:18 UTC 2019
+  Test cpld_fv3_384_mom6_cice_cold_atm_flux starting at Wed Nov 13 15:48:25 UTC 2019 (Fully coupled FV3-MOM6-CICE system - cold 384)
+  Wed Nov 13 15:48:25 UTC 2019
   phyf001.tile1.nc: bit-for-bit identical
   phyf001.tile2.nc: bit-for-bit identical
   phyf001.tile3.nc: bit-for-bit identical
@@ -119,14 +122,14 @@ TEST #2: PASS
   mediator_FBOcn_o_restart.nc: bit-for-bit identical
   mediator_scalars_restart.txt: bit-for-bit identical
   Executable did not change during test suite:
-    File: /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/exec/fv3_mom6_cice.exe
-    Expected md5sum: 5d3e0efa487527efac2d7e32d3d0a113
-    Actual md5sum: 5d3e0efa487527efac2d7e32d3d0a113
-  TEST PASSED AT Fri Nov  8 17:33:06 UTC 2019
+    File: /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/exec/fv3_mom6_cice.exe
+    Expected md5sum: fa0dba069b6668cf64f6e10529c0e5e1
+    Actual md5sum: fa0dba069b6668cf64f6e10529c0e5e1
+  TEST PASSED AT Wed Nov 13 15:54:21 UTC 2019
 
 TEST #3: PASS
-  Test cpld_fv3_mom6_cice_cold_atm_flux starting at Fri Nov 8 17:27:18 UTC 2019 (Fully coupled FV3-MOM6-CICE system - cold start)
-  Fri Nov  8 17:27:18 UTC 2019
+  Test cpld_fv3_mom6_cice_cold_atm_flux starting at Wed Nov 13 15:48:25 UTC 2019 (Fully coupled FV3-MOM6-CICE system - cold start)
+  Wed Nov 13 15:48:25 UTC 2019
   phyf001.tile1.nc: bit-for-bit identical
   phyf001.tile2.nc: bit-for-bit identical
   phyf001.tile3.nc: bit-for-bit identical
@@ -182,14 +185,14 @@ TEST #3: PASS
   mediator_FBOcn_o_restart.nc: bit-for-bit identical
   mediator_scalars_restart.txt: bit-for-bit identical
   Executable did not change during test suite:
-    File: /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/exec/fv3_mom6_cice.exe
-    Expected md5sum: 5d3e0efa487527efac2d7e32d3d0a113
-    Actual md5sum: 5d3e0efa487527efac2d7e32d3d0a113
-  TEST PASSED AT Fri Nov  8 17:29:49 UTC 2019
+    File: /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/exec/fv3_mom6_cice.exe
+    Expected md5sum: fa0dba069b6668cf64f6e10529c0e5e1
+    Actual md5sum: fa0dba069b6668cf64f6e10529c0e5e1
+  TEST PASSED AT Wed Nov 13 15:51:04 UTC 2019
 
 TEST #4: PASS
-  Test cpld_fv3_mom6_cice_2d_atm_flux starting at Fri Nov 8 17:27:18 UTC 2019 (Fully coupled FV3-MOM6-CICE system - 2d_warm)
-  Fri Nov  8 17:27:18 UTC 2019
+  Test cpld_fv3_mom6_cice_2d_atm_flux starting at Wed Nov 13 16:06:32 UTC 2019 (Fully coupled FV3-MOM6-CICE system - 2d_warm)
+  Wed Nov 13 16:06:32 UTC 2019
   phyf048.tile1.nc: bit-for-bit identical
   phyf048.tile2.nc: bit-for-bit identical
   phyf048.tile3.nc: bit-for-bit identical
@@ -203,11 +206,11 @@ TEST #4: PASS
   dynf048.tile5.nc: bit-for-bit identical
   dynf048.tile6.nc: bit-for-bit identical
   Executable did not change during test suite:
-    File: /scratch2/NCEPDEV/stmp1/Denise.Worthen/rtgen.86760/exec/fv3_mom6_cice.exe
-    Expected md5sum: 5d3e0efa487527efac2d7e32d3d0a113
-    Actual md5sum: 5d3e0efa487527efac2d7e32d3d0a113
-  TEST PASSED AT Fri Nov  8 17:44:35 UTC 2019
-WORKFLOW REPORT AT Fri Nov  8 18:19:26 2019 (+1573237166)
+    File: /scratch2/NCEPDEV/stmp1/Denise.Worthen/RTS/rtgen.158979/exec/fv3_mom6_cice.exe
+    Expected md5sum: fa0dba069b6668cf64f6e10529c0e5e1
+    Actual md5sum: fa0dba069b6668cf64f6e10529c0e5e1
+  TEST PASSED AT Wed Nov 13 16:23:36 UTC 2019
+WORKFLOW REPORT AT Wed Nov 13 16:54:52 2019 (+1573664092)
 Tests: 0 failed, 4 passed out of 4
 Builds: 0 failed, 1 passed out of 1
 REGRESSION TEST WAS SUCCESSFUL


### PR DESCRIPTION
* re-arranges the filters input section so that items copied from
@[parmNEMS] are not clobbered by wildcard copies preceeding them
in list; updates the fnsmcc file in the benchmark cases to match
the workflow; adds addtional text clarifying source of mediator
cold starts in the case of optional benchmark or datesuite runs

All regression tests pass.

* Add logs from regression test